### PR TITLE
Patch change: updated bingo to only use 1 endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,10 +137,6 @@ Length: A number for how many characters long the password will be.
 Complexity: Basic, Simple, or Complex are the only valid options. Basic is only lowercase letters. Simple is lowercase letters and numbers. Complex is Lower and Uppercase letters, numbers, and symbols.
 
 ## /bingo endpoint
-Turns the /bingo/generate endpoint and turns it into a flask app.
-Is 2 different endpoints for testing, but will likely be combined in the future.
-
-## /bingo/generate endpoint
 This endpoint generates a 5x5 bingo card that is a list of dictionaries with random bingo numbers. 
 Each dictionary is a cell in the bingo card, storing the value and if the cell is marked.
 Every 5 cells increases the range of possible values by 15.

--- a/app.py
+++ b/app.py
@@ -418,7 +418,7 @@ def create_app():
         return random.choice(answers)
         
 
-    @app.route("/bingo/generate")
+    @app.route("/bingo")
     def generate_bingo_card():
     #   generates 5x5 card as 1 list, each column adding 15 to the range
         card = (
@@ -431,11 +431,7 @@ def create_app():
 
         card[get_bingo_index(2,2)]["value"] = "FREE"
         card[get_bingo_index(2,2)]["marked"] = True
-        return card
-
-    @app.route("/bingo")
-    def create_card():
-        return jsonify({"card": generate_bingo_card()}), 200
+        return jsonify({"card": card}), 200
 
     @app.route("/__endpoints", methods=["GET"])
     def list_endpoints():

--- a/test/test_bingo_card.py
+++ b/test/test_bingo_card.py
@@ -64,4 +64,7 @@ class TestGenerateCard(unittest.TestCase):
             else:
                 self.assertFalse(cell["marked"],
                                 f"Cell with value {cell['value']} should still be False")
-
+    
+    def test_bingo_generate_doesnt_exist(self):
+        response = self.client.get("/bingo/generate")
+        self.assertEqual(response.status_code, 404)


### PR DESCRIPTION
Is a patch change since it removed unnecessary routing from one endpoint to another. Can be a Major change since an endpoint was deleted, but the bingo/generate endpoint was never intended to be used by a user, only the /bingo endpoint  was intended to be used.