### PR TITLE
Added dice bets and test

### DIFF
--- a/app.py
+++ b/app.py
@@ -48,7 +48,37 @@ def create_app():
         weights = [70, 20, 9, 1]
         # Return three top-level keys so tests expecting a dict of length 3 succeed
         return jsonify({"pool": pool, "rarities": rarities, "weights": weights})
-    
+#start of dice bets
+    @app.route("/api/dice/bet", methods=["POST"])
+    def dice_bet():
+        """User bets on which side of a dice will land (1-6)."""
+        if not request.is_json:
+            return jsonify({"error": "Request must be in JSON format"}), 400
+
+        data = request.get_json()
+        try:
+            bet_choice = int(data.get("choice"))
+            bet_amount = float(data.get("bet"))
+        except (TypeError, ValueError):
+            return jsonify({"error": "Invalid input types"}), 400
+
+        # Validate range and bet
+        if bet_choice not in range(1, 7):
+            return jsonify({"error": "Choice must be between 1 and 6"}), 400
+        if bet_amount <= 0:
+            return jsonify({"error": "Bet must be a positive number"}), 400
+
+        roll = random.randint(1, 6)
+        win = (roll == bet_choice)
+        winnings = bet_amount * 2 if win else 0
+
+        return jsonify({
+            "rolled": roll,
+            "choice": bet_choice,
+            "result": "win" if win else "lose",
+            "winnings": winnings
+        })
+
     @app.route('/yatzy')
     def yatzy():
         result = []
@@ -844,6 +874,7 @@ def roll_dice(sides):
             "is_even": result % 2 == 0,
         }
     )
+
 
 
 @app.route("/generatePassword")

--- a/test/test_dice_bet.py
+++ b/test/test_dice_bet.py
@@ -1,0 +1,17 @@
+def test_dice_bet_valid(client):
+    response = client.post("/api/dice/bet", json={"choice": 3, "bet": 10})
+    assert response.status_code == 200
+    data = response.get_json()
+    assert "rolled" in data
+    assert "result" in data
+    assert "winnings" in data
+
+def test_dice_bet_invalid_choice(client):
+    response = client.post("/api/dice/bet", json={"choice": 8, "bet": 10})
+    assert response.status_code == 400
+    data = response.get_json()
+    assert "error" in data
+
+def test_dice_bet_invalid_json(client):
+    response = client.post("/api/dice/bet", data="not json")
+    assert response.status_code == 400


### PR DESCRIPTION
Added a new /api/dice/bet endpoint that allows users to bet on which side of a dice (1–6) will land.
Returns the rolled number, bet choice, and winnings.
This change adds functionality without breaking existing routes — Minor semantic change.